### PR TITLE
[aptos] Update aptos to reduce REST API calls, fix faucet URL

### DIFF
--- a/packages/app/src/aptos/config.ts
+++ b/packages/app/src/aptos/config.ts
@@ -24,7 +24,7 @@ export const aptosTestnet: AptosChainConfig = {
   network: 'testnet',
   rpcUrl: process.env.NEXT_PUBLIC_APTOS_TESTNET_RPC_URL || 'https://api.testnet.aptoslabs.com/v1',
   indexerUrl: 'https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql',
-  faucetUrl: 'https://faucet.testnet.aptoslabs.com',
+  faucetUrl: 'https://aptos.dev/en/network/faucet',
   explorerUrl: 'https://explorer.aptoslabs.com/?network=testnet',
   nativeCurrency: {
     name: 'Aptos',

--- a/packages/app/src/hooks/useChainRace.ts
+++ b/packages/app/src/hooks/useChainRace.ts
@@ -12,7 +12,14 @@ import { Connection, SystemProgram, Transaction, sendAndConfirmTransaction } fro
 import type { SolanaChainConfig } from "@/solana/config";
 import type { FuelChainConfig } from "@/fuel/config";
 import type { AptosChainConfig } from "@/aptos/config";
-import { Aptos, AptosConfig, Network, type SimpleTransaction, type AccountAuthenticator } from "@aptos-labs/ts-sdk";
+import {
+  Aptos,
+  AptosConfig,
+  Network,
+  type SimpleTransaction,
+  type AccountAuthenticator,
+  TypeTagAddress, TypeTagU64, U64, AccountAddress
+} from "@aptos-labs/ts-sdk";
 import { getGeo } from "@/lib/geo";
 import { saveRaceResults } from "@/lib/api";
 import { WalletUnlocked, bn, Provider, type TransactionRequest, ScriptTransactionRequest, type Coin, ResolvedOutput, OutputChange } from "fuels";
@@ -90,7 +97,7 @@ function isFuelChain(chain: AnyChainConfig): chain is FuelChainConfig {
 }
 
 function isAptosChain(chain: AnyChainConfig): chain is AptosChainConfig {
-  return 'network' in chain && typeof chain.network === 'string' && 
+  return 'network' in chain && typeof chain.network === 'string' &&
          ('id' in chain && typeof chain.id === 'string' && chain.id.startsWith('aptos-'));
 }
 
@@ -156,7 +163,7 @@ export function useChainRace() {
     }
     return 'Testnet'; // Default to testnet for safety
   });
-  
+
   const [selectedChains, setSelectedChains] = useState<(number | string)[]>(() => {
     // Load saved chain selection from localStorage if available
     if (typeof window !== 'undefined') {
@@ -224,7 +231,7 @@ export function useChainRace() {
           if (layerFilter !== 'L1') return false;
         }
       }
-      
+
       // Network filter (mainnet vs testnet) - no "Both" option
       if (isEvmChain(chain)) {
         const isTestnet = chain.testnet;
@@ -244,11 +251,11 @@ export function useChainRace() {
         if (networkFilter === 'Mainnet' && !isMainnet) return false;
         if (networkFilter === 'Testnet' && isMainnet) return false;
       }
-      
+
       return true;
     });
   }, [layerFilter, networkFilter]);
-  
+
   // Define checkBalances before using it in useEffect
   const checkBalances = useCallback(async () => {
     if (!account || !solanaReady || !solanaPublicKey || !fuelReady || !fuelWallet || !aptosReady || !aptosAccount) return;
@@ -337,7 +344,7 @@ export function useChainRace() {
               };
             } else if (isAptosChain(chain)) {
               // Aptos balance check
-              const config = new AptosConfig({ 
+              const config = new AptosConfig({
                 network: chain.network as Network,
                 fullnode: chain.rpcUrl,
               });
@@ -567,10 +574,10 @@ export function useChainRace() {
     if (!account || !privateKey || !solanaKeypair || !fuelWallet || !aptosAccount || status !== "ready") return;
 
     setStatus("racing");
-    
+
     // Filter chains based on layer filter AND selection (support both EVM and Solana)
     const filteredChains = getFilteredChains();
-    const activeChains = filteredChains.filter(chain => 
+    const activeChains = filteredChains.filter(chain =>
       selectedChains.includes(isEvmChain(chain) ? chain.id : chain.id)
     );
 
@@ -692,11 +699,11 @@ export function useChainRace() {
 
             // Pre-sign all Solana transactions
             const signedTransactions = [];
-            
+
             try {
               // Get the latest blockhash for all transactions
               const { blockhash } = await workingConnection.getLatestBlockhash(chain.commitment);
-              
+
               for (let txIndex = 0; txIndex < transactionCount; txIndex++) {
                 try {
                   // Create transaction with unique transfer amount to avoid duplicate signatures
@@ -775,7 +782,7 @@ export function useChainRace() {
             };
           } else if (isAptosChain(chain)) {
             // Aptos chain data fetching
-            const config = new AptosConfig({ 
+            const config = new AptosConfig({
               network: (chain as AptosChainConfig).network as Network,
               fullnode: (chain as AptosChainConfig).rpcUrl,
             });
@@ -885,7 +892,7 @@ export function useChainRace() {
               const fallbackGasPrice = BigInt(
                 chain.id === 10143 ? 60000000000 : // Monad has higher gas requirements
                   chain.id === 8453 ? 2000000000 :   // Base mainnet
-                    chain.id === 6342 ? 3000000000 :   // MegaETH 
+                    chain.id === 6342 ? 3000000000 :   // MegaETH
                       chain.id === 17180 ? 1500000000 :  // Sonic
                         1000000000                         // Default fallback (1 gwei)
               );
@@ -1174,7 +1181,7 @@ export function useChainRace() {
               } else {
                 // Fallback: create fresh transaction if no pre-signed transaction available
                 console.warn(`No pre-signed transaction for Solana tx #${txIndex}, creating fresh transaction`);
-                
+
                 const transaction = new Transaction().add(
                   SystemProgram.transfer({
                     fromPubkey: solanaKeypair.publicKey,
@@ -1491,6 +1498,46 @@ export function useChainRace() {
           }
 
           const aptos = currentChainData.aptos;
+          // Manage the sequence number internally
+          let aptosSeqNo: bigint | undefined = undefined;
+
+          // Retrieves the sequence number for the Aptos account and sets it the first time
+          const getSequenceNumber = async (accountAddress: AccountAddress) => {
+            if (aptosSeqNo === undefined) {
+              // Fetch the sequence number only once
+              const accountInfo = await aptos.getAccountInfo({accountAddress});
+              aptosSeqNo = BigInt(accountInfo.sequence_number);
+            }
+          }
+
+          // Builds and signs a transaction for Aptos
+          const buildAndSignTransaction = async (txIndex: number) => {
+            const transaction = await aptos.transaction.build.simple({
+              sender: aptosAccount.accountAddress,
+              data: {
+                function: "0x1::aptos_account::transfer",
+                functionArguments: [aptosAccount.accountAddress, new U64(0)], // Transfer 0 APT to self
+                abi: {
+                  // ABI skips call to check arguments
+                  signers: 1,
+                  typeParameters: [],
+                  parameters: [new TypeTagAddress(), new TypeTagU64()]
+                }
+              },
+              options: {
+                accountSequenceNumber: aptosSeqNo! + BigInt(txIndex),
+                gasUnitPrice: 100, // Default gas price, no reason to estimate
+                maxGasAmount: 1000, // Set a max gas, no need for it to be too high
+              }
+            })
+            return {
+              transaction,
+              senderAuthenticator: aptos.transaction.sign({
+                signer: aptosAccount,
+                transaction,
+              })
+            }
+          }
 
           // Run the specified number of transactions
           for (let txIndex = 0; txIndex < transactionCount; txIndex++) {
@@ -1504,30 +1551,19 @@ export function useChainRace() {
               let txLatency = 0;
               const txStartTime = Date.now();
 
-              // Create and sign fresh transaction for each execution
-              // This avoids sequence number issues with Aptos
-              
-              // Create a simple transfer transaction (0 APT to self)
-              const transaction = await aptos.transaction.build.simple({
-                sender: aptosAccount.accountAddress,
-                data: {
-                  function: "0x1::aptos_account::transfer",
-                  functionArguments: [aptosAccount.accountAddress, 0], // Transfer 0 APT to self
-                },
-              });
+              // Fetch sequence number the first time, incrementing after
+              await getSequenceNumber(aptosAccount.accountAddress);
 
               // Sign and submit the transaction
-              const response = await aptos.transaction.submit.simple({
-                transaction,
-                senderAuthenticator: aptos.transaction.sign({
-                  signer: aptosAccount,
-                  transaction,
-                }),
-              });
+              const signedTxn = await buildAndSignTransaction(txIndex);
+              const response = await aptos.transaction.submit.simple(signedTxn);
 
               // Wait for transaction confirmation
               await aptos.waitForTransaction({
                 transactionHash: response.hash,
+                options: {
+                  waitForIndexer: false // Unnecessary, no indexer calls made
+                }
               });
 
               // Calculate transaction latency


### PR DESCRIPTION
1. Skips using remote ABI, it's a well known function, so not needed (can always be set manually for any call)
2. Fetches Sequence Number once.  Increments after that, as each transaction must be sequential.  Only reason for fetching multiple times if you don't know if there are multiple submitters / don't know one in the middle failed.
3. Not waiting on indexer, it isn't used in this context.
4. Fixed faucet URL, the given URL right now is the programmable Faucet, which is disabled due to abuse.  The new URL gives the interactive faucet for GitHub login, like most of the others.
5. Split functionality clearly into functions, to make it easier to read / reason
6. Set a default max gas and gas price, which shouldn't cause any issues here.  Though, keeping in mind a higher gas price could be used for priority / make these faster. (avoiding roundtrip to estimate that).  Max gas is fixed here, and should not change.
7. First transaction is slower to make up for extra call to get sequence number
8. My IDE also changed some whitespace