### PR TITLE
Fix Starknet Transaction Confirmation Wait Logic

### DIFF
--- a/packages/app/src/hooks/useChainRace.ts
+++ b/packages/app/src/hooks/useChainRace.ts
@@ -2102,7 +2102,10 @@ export function useChainRace() {
                 }
               );
               // Wait for transaction confirmation
-              await provider.waitForTransaction(transferTxHash);         
+              await provider.waitForTransaction(transferTxHash,{
+                retryInterval: 400,
+                successStates: ['ACCEPTED_ON_L2']
+              });         
               // Calculate transaction latency
               const endTime = Date.now();
               const txLatency = endTime - startTime;

--- a/packages/app/src/hooks/useStarknetEmbeddedWallet.ts
+++ b/packages/app/src/hooks/useStarknetEmbeddedWallet.ts
@@ -107,7 +107,10 @@ import { useEffect, useState } from "react";
       
         const { transaction_hash: transferTxHash } =
           await account0.execute(transferCall, { version: 3 });
-        await provider.waitForTransaction(transferTxHash);
+        await provider.waitForTransaction(transferTxHash,{
+          retryInterval: 400,
+          successStates: ['ACCEPTED_ON_L2']
+        });
         
         updateProgress("Crunching the numbers...", 40);
         const balanceofnewaccountTransfer =
@@ -132,7 +135,10 @@ import { useEffect, useState } from "react";
         updateProgress("Deploying account...", 80);
         const { transaction_hash: AXdAth, contract_address: AXcontractFinalAddress } =
           await accountAX.deployAccount(deployAccountPayload, { version: 3 });
-        await provider.waitForTransaction(AXdAth);
+        await provider.waitForTransaction(AXdAth,{
+          retryInterval: 400,
+          successStates: ['ACCEPTED_ON_L2']
+        });
 
         updateProgress("Finalizing setup...", 90);
         const newAccount = new Account(provider, AXcontractFinalAddress, privateKeyAX);


### PR DESCRIPTION

## Description
This PR improves the transaction confirmation waiting logic for Starknet chains in the Chain Derby race. The current implementation was not properly waiting for transaction confirmations since it was waiting for both L1 and L2 confirmation (But now only waiting to confirm L2 acceptance). This fix however  reduced the total transaction time down to 39.32s from about 115.56 which is still relatively slow compared to other chains whose total confirmation time is between 4.5s to 10s.  

## Changes
- Updated the Starknet transaction confirmation wait logic to use proper success states
- Added retry interval configuration for better reliability
- Ensures transactions are confirmed on L2 rather than both L1 and L2. 

## Technical Details
The main changes are in the Starknet transaction processing section: 
```typescript
await provider.waitForTransaction(transferTxHash, {
  retryInterval: 400,
  successStates: ['ACCEPTED_ON_L2']
});
```

This ensures that:
1. Transactions are properly confirmed on L2
2. We have a reasonable retry interval (400ms) for faster confirmation - It should be noted that the lower the retryInterval, the higher the chances of running into nonce issues.
3. We only consider a transaction successful when it's accepted on L2.